### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Use the following commands to set up and seed your database:
 Run the command in the terminal so that the config loads correctly
 `$ cp .env.template .env`
 
+### Installing your dependencies
+
+Run the following command in the terminal:
+`$ npm install`
+
 ### Starting your development server
 
 Run the following command in the terminal:


### PR DESCRIPTION
I was unable to run the command 'npm start' due to the following error message: "[nodemon] failed to start process, "babel-node" exec not found." I ran the command 'npm install' and then attempted 'npm start' and the issue was resolved. I then inserted lines 34-37 in the README.md file for future users.